### PR TITLE
Git 13

### DIFF
--- a/bootstrap/hub/addons.yaml
+++ b/bootstrap/hub/addons.yaml
@@ -4,6 +4,8 @@ metadata:
   name: addons
   namespace: argocd
 spec:
+  goTemplate: true
+  goTemplateOptions: ["missingkey=error"]
   syncPolicy:
     preserveResourcesOnDeletion: true
   generators:
@@ -18,15 +20,30 @@ spec:
       name: 'addons'
     spec:
       project: default
+      # Deployments mode (GIT-13): if the cluster secret carries a non-empty
+      # `addons_private_repo_url`, target the private deployments repo's bootstrap/
+      # (a Kustomize build that imports the clean public appsets, layers private values
+      # and adds extra apps). Otherwise fall back to the public catalogue directory
+      # (trial mode, `directory.recurse` added by templatePatch below). The public
+      # `addons_repo_url` is never repointed, so every child appset keeps sourcing its
+      # `$values` base from the public catalogue.
       source:
-        repoURL: '{{metadata.annotations.addons_repo_url}}'
-        path: '{{metadata.annotations.addons_repo_basepath}}/{{metadata.annotations.addons_repo_path}}'
-        targetRevision: '{{metadata.annotations.addons_repo_revision}}'
+        repoURL: '{{- if .metadata.annotations.addons_private_repo_url }}{{ .metadata.annotations.addons_private_repo_url }}{{- else }}{{ .metadata.annotations.addons_repo_url }}{{- end }}'
+        targetRevision: '{{- if .metadata.annotations.addons_private_repo_url }}{{ .metadata.annotations.addons_private_repo_revision }}{{- else }}{{ .metadata.annotations.addons_repo_revision }}{{- end }}'
+        path: '{{- if .metadata.annotations.addons_private_repo_url }}{{ .metadata.annotations.addons_private_repo_basepath }}/bootstrap{{- else }}{{ .metadata.annotations.addons_repo_basepath }}/{{ .metadata.annotations.addons_repo_path }}{{- end }}'
+      destination:
+        namespace: 'argocd'
+        name: '{{ .name }}'
+      syncPolicy:
+        automated: {}
+  # Trial mode only: the public catalogue path is a plain directory of appsets, so it
+  # needs directory.recurse. In deployments mode the private bootstrap/ is a Kustomize
+  # build (auto-detected), and `directory` must be absent — so this patch is empty there.
+  templatePatch: |
+    {{- if not .metadata.annotations.addons_private_repo_url }}
+    spec:
+      source:
         directory:
           recurse: true
           exclude: exclude/*
-      destination:
-        namespace: 'argocd'
-        name: '{{name}}'
-      syncPolicy:
-        automated: {}
+    {{- end }}

--- a/bootstrap/hub/workloads.yaml
+++ b/bootstrap/hub/workloads.yaml
@@ -4,6 +4,8 @@ metadata:
   name: workloads
   namespace: argocd
 spec:
+  goTemplate: true
+  goTemplateOptions: ["missingkey=error"]
   syncPolicy:
     preserveResourcesOnDeletion: false # in production environments should be true
   generators:
@@ -18,16 +20,30 @@ spec:
       name: 'workloads'
     spec:
       project: default
+      # Deployments mode (GIT-13): if the cluster secret carries a non-empty
+      # `workloads_private_repo_url`, target the private deployments repo's bootstrap/
+      # (a Kustomize build that imports the clean public appsets, layers private values
+      # and adds extra apps). Otherwise fall back to the public catalogue directory
+      # (trial mode, `directory.recurse` added by templatePatch below). The public
+      # `workloads_repo_url` is never repointed, so every child appset keeps sourcing its
+      # `$workloads` base from the public catalogue.
       source:
-        repoURL: '{{metadata.annotations.workloads_repo_url}}'
-        path: '{{metadata.annotations.workloads_repo_basepath}}/{{metadata.annotations.workloads_repo_path}}'
-        targetRevision: '{{metadata.annotations.workloads_repo_revision}}'
+        repoURL: '{{- if .metadata.annotations.workloads_private_repo_url }}{{ .metadata.annotations.workloads_private_repo_url }}{{- else }}{{ .metadata.annotations.workloads_repo_url }}{{- end }}'
+        targetRevision: '{{- if .metadata.annotations.workloads_private_repo_url }}{{ .metadata.annotations.workloads_private_repo_revision }}{{- else }}{{ .metadata.annotations.workloads_repo_revision }}{{- end }}'
+        path: '{{- if .metadata.annotations.workloads_private_repo_url }}{{ .metadata.annotations.workloads_private_repo_basepath }}/bootstrap{{- else }}{{ .metadata.annotations.workloads_repo_basepath }}/{{ .metadata.annotations.workloads_repo_path }}{{- end }}'
+      destination:
+        namespace: 'argocd'
+        name: '{{ .name }}'
+      syncPolicy:
+        automated: {}
+  # Trial mode only: the public catalogue path is a plain directory of appsets, so it
+  # needs directory.recurse. In deployments mode the private bootstrap/ is a Kustomize
+  # build (auto-detected), and `directory` must be absent — so this patch is empty there.
+  templatePatch: |
+    {{- if not .metadata.annotations.workloads_private_repo_url }}
+    spec:
+      source:
         directory:
           recurse: true
           exclude: exclude/*
-      destination:
-        namespace: 'argocd'
-        name: '{{name}}'
-      syncPolicy:
-        automated: {}
-        preserveResourcesOnDeletion: false  # Should be true in production
+    {{- end }}

--- a/docs/private-overlays-design.md
+++ b/docs/private-overlays-design.md
@@ -1,0 +1,151 @@
+# Private overlays / deployments repo — design (GIT-13)
+
+Status: **agreed design, pre-implementation** · Jira: **GIT-13** · Last updated: 2026-08-08
+
+## Purpose
+
+Let implementers layer **private, credentialed, per-organisation configuration** (values,
+secrets, cluster resources) on top of the **public** add-on and workload catalogues —
+without modifying or forking the public repos, with a deterministic precedence order.
+
+## Two kinds of repo
+
+| | Public catalogues (`gitops-addons`, `gitops-workloads`) | Private **deployments** repo (e.g. `gitops-private`) |
+|---|---|---|
+| Role | Generic, reusable capability library (appsets, base/default + environment values, optionally vendored charts) | An organisation's **deployment declaration**: which clusters, add-ons, workloads and resources it runs, plus private/cluster-specific values and secrets |
+| Visibility | Public — cloneable/forkable | Private — SSH deploy key |
+| Ownership of "what boots" | Provides appsets usable as-is for a **trial** | **Owns `bootstrap/`** — decides which appsets boot for that org, and carries the Kustomize patching that layers private data over the public appsets |
+
+## Two modes of operation
+
+1. **Trial / public-only.** Bootstrap the control plane against just the public catalogues.
+   Everything works out of the box so an evaluator can see what GitOps does with near-zero
+   effort. Forking the public repos is possible but then you own the divergence.
+   **⇒ The public catalogue appsets must stay clean — they must never reference a private repo.**
+2. **Deployments mode.** An organisation supplies a private deployments repo. The control-plane
+   root app points at the **private repo's `bootstrap/`** instead of the public appsets. That
+   bootstrap imports the public appsets and **patches in** the private overlay.
+
+The mode is selected per cluster at registration, via the repo path/basepath annotations on the
+Argo CD cluster secret — no code change, no per-cluster label toggle.
+
+## Repository layouts
+
+**Public catalogues stay as they are today** — `basepath` bridges any shape difference, so no
+public restructure is required. (Bundling a `charts/` folder in the public repos may make sense
+later; deferred.)
+
+**Private deployments repo** (this is the shape `gitops-private` must adopt):
+
+```
+<private repo>/
+  addons/
+    bootstrap/       # ApplicationSets that boot; Kustomize that imports the public
+                     # addon appsets and patches in the private source + $private values
+    charts/          # vendored Helm charts needed at bootstrap, or unpublished charts
+                     # not worth their own repo (secret-gated registries can't be pulled
+                     # before the secret exists — chicken-and-egg, e.g. external-secrets)
+    clusters/<cluster>/<app>/values.yaml     # per-cluster (private, most specific)
+    environments/<env>/<app>/values.yaml     # per-environment (private)
+    .gitignore
+    README.md
+  workloads/
+    bootstrap/ | charts/ | clusters/ | environments/ | .gitignore | README.md
+```
+
+`addons/` and `workloads/` are **self-contained siblings**, so the same layout serves **one
+combined repo or two split repos** by config alone (see the annotation contract).
+
+## Layering mechanism
+
+The private repo's `bootstrap/` uses **Kustomize** (already a first-class dependency of this
+repo — see `bootstrap/argocd/kustomization.yaml` + ksops) to:
+
+1. import the clean public appsets as resources, and
+2. **patch** each to add a private `ref` source and append the private value files, e.g.
+
+   - add source: `repoURL: '{{ .metadata.annotations.<kind>_private_repo_url }}'`,
+     `targetRevision: '{{ … _private_repo_revision }}'`, `ref: private` (URL is
+     **annotation-templated**, so each org/cluster patches in **its own** private repo);
+   - append valueFiles:
+     `$private/<basepath>/environments/{{ env }}/<app>/values.yaml`,
+     `$private/<basepath>/clusters/{{ cluster }}/<app>/values.yaml`.
+
+Non-Helm, per-cluster **resources** (StorageClasses, etc.) layer via Argo-native
+`source.kustomize.patches` driven by annotations (the `resources` appset pattern) — this is
+GIT-20 territory, not required for GIT-13's value/secret layering.
+
+### Precedence (lowest → highest, last wins)
+
+```
+public  environments/default/<kind>/<app>/values.yaml
+public  environments/<env>/<kind>/<app>/values.yaml
+private environments/<env>/<kind>/<app>/values.yaml
+private clusters/<cluster>/<kind>/<app>/values.yaml
+```
+
+Cluster is the most specific layer and is **private only** — real cluster names, IPs and hosts
+are private facts. There is no *organisation* public-cluster layer. (The public repo may retain
+a `clusters/` tree for its own trial/demo purposes; org deployments do not use it.)
+
+## Annotation contract (Terraform → Argo CD cluster secret)
+
+Existing (public): `addons_repo_{url,basepath,path,revision}`,
+`workloads_repo_{url,basepath,path,revision}`.
+
+New (private, GIT-13): for each kind `{addons, workloads}`:
+
+```
+<kind>_private_repo_url        # SSH URL of the deployments repo (per org/cluster)
+<kind>_private_repo_basepath   # "addons" | "workloads" — subtree within the private repo
+<kind>_private_repo_revision   # branch/ref
+```
+
+- **Single private repo:** both `*_private_repo_url` point at the same repo; basepaths are
+  `addons` / `workloads`.
+- **Two private repos:** point the two URLs at different repos; basepaths unchanged.
+- Built from `var.gitops_private_org` (SSH prefix, distinct from the HTTPS `gitops_org`) +
+  `var.gitops_{addons,workloads}_private_{repo,revision}`, per Terraform stack.
+- No `enable_private_overlays` label is needed — mode is chosen by which appsets the root app
+  loads (public vs private `bootstrap/`). *(The toggle added in the first Phase-1 pass is
+  therefore dropped.)*
+
+## Secrets
+
+- **SOPS decrypted/applied from outside the cluster only** — no in-cluster SOPS (matches the
+  ksops-local pattern already used for the Argo repo secrets). Applied via
+  `sops -d … | kubectl apply -f -` / local Kustomize build.
+- **Runtime secrets via External Secrets.** ESO does not exist yet — it depends on the
+  external-secrets add-on (**GIT-6/GIT-10**) and a backend (**GIT-7**). ESO is required by the
+  GIT-13 acceptance criteria, so **GIT-13 cannot be fully closed until ESO lands**; it is the
+  next piece of work. Vendored `charts/` in the private `bootstrap/` breaks the chicken-and-egg
+  for the external-secrets chart itself.
+- The SSH deploy key for the private repo is stored as an Argo CD repository Secret,
+  SOPS-encrypted, applied out-of-cluster.
+
+## Scope & related tickets
+
+- **GIT-13 (this):** the private-overlay / deployments-repo pattern for **values + secrets**,
+  proven end-to-end on ivylen (single combined private repo).
+- **GIT-6 / GIT-10:** external-secrets add-on — blocks final GIT-13 closure.
+- **GIT-7:** Vault backend.
+- **GIT-20:** per-cluster resources via `source.kustomize.patches` (same annotation-driven
+  Kustomize technique, different content).
+- Deferred: bundling a `charts/` folder in the public catalogues.
+
+## Implementation phases
+
+1. **Terraform** (`gitops-control-plane`, branch `GIT-13`): add `*_private_repo_basepath`;
+   keep `*_private_repo_url/revision` + `gitops_private_org`; remove the now-unused
+   `enable_private_overlays` toggle. (Partly done in the first Phase-1 pass; needs the basepath
+   addition and toggle removal.)
+2. **Private repo** (`gitops-private`): restructure to the `addons/` + `workloads/` layout with
+   real `bootstrap/` (Kustomize import-and-patch), `charts/`, `clusters/`, `environments/`.
+   Re-home the seeded ivylen home-assistant overlay under `workloads/`.
+3. **Control-plane bootstrap:** allow the root app to target the private repo's `bootstrap/`
+   for deployments-mode clusters (via path/basepath annotations); public appsets untouched.
+4. **Credentials:** private-repo SSH deploy key as a SOPS-encrypted Argo repository Secret.
+5. **Validate on ivylen:** public deploys, private overlay overrides a value (LoadBalancer IP),
+   no public-catalogue change needed.
+6. **ESO integration** (GIT-6/10 + GIT-7) — unblocks final GIT-13 closure.
+```

--- a/terraform/hub-spoke/hub/locals.tf
+++ b/terraform/hub-spoke/hub/locals.tf
@@ -26,10 +26,12 @@ locals {
   gitops_workloads_path     = var.gitops_workloads_path
   gitops_workloads_revision = var.gitops_workloads_revision
 
-  # Private overlay repos (GIT-13) — SSH-accessed, values-only
+  # Private overlay / deployments repos (GIT-13) — SSH-accessed
   gitops_addons_private_url         = "${var.gitops_private_org}/${var.gitops_addons_private_repo}"
+  gitops_addons_private_basepath    = var.gitops_addons_private_basepath
   gitops_addons_private_revision    = var.gitops_addons_private_revision
   gitops_workloads_private_url      = "${var.gitops_private_org}/${var.gitops_workloads_private_repo}"
+  gitops_workloads_private_basepath = var.gitops_workloads_private_basepath
   gitops_workloads_private_revision = var.gitops_workloads_private_revision
 
   # Cluster labels
@@ -71,11 +73,13 @@ locals {
       workloads_repo_revision = local.gitops_workloads_revision
     },
     {
-      # Private overlay repos (GIT-13). Consumed by catalogue ApplicationSets
-      # only for clusters labelled enable_private_overlays=true.
+      # Private overlay / deployments repos (GIT-13). Consumed by the private repo's
+      # bootstrap Kustomize (deployments mode) to template per-cluster overlay sources.
       addons_private_repo_url         = local.gitops_addons_private_url
+      addons_private_repo_basepath    = local.gitops_addons_private_basepath
       addons_private_repo_revision    = local.gitops_addons_private_revision
       workloads_private_repo_url      = local.gitops_workloads_private_url
+      workloads_private_repo_basepath = local.gitops_workloads_private_basepath
       workloads_private_repo_revision = local.gitops_workloads_private_revision
     },
   )

--- a/terraform/hub-spoke/hub/locals.tf
+++ b/terraform/hub-spoke/hub/locals.tf
@@ -26,11 +26,13 @@ locals {
   gitops_workloads_path     = var.gitops_workloads_path
   gitops_workloads_revision = var.gitops_workloads_revision
 
-  # Private overlay / deployments repos (GIT-13) — SSH-accessed
-  gitops_addons_private_url         = "${var.gitops_private_org}/${var.gitops_addons_private_repo}"
+  # Private deployments repos (GIT-13) — SSH-accessed. URL is empty unless a repo is set
+  # (opt-in), so a public-only trial cluster emits no private annotation and the root
+  # bootstrap appset falls back to the public catalogue.
+  gitops_addons_private_url         = var.gitops_addons_private_repo == "" ? "" : "${var.gitops_private_org}/${var.gitops_addons_private_repo}"
   gitops_addons_private_basepath    = var.gitops_addons_private_basepath
   gitops_addons_private_revision    = var.gitops_addons_private_revision
-  gitops_workloads_private_url      = "${var.gitops_private_org}/${var.gitops_workloads_private_repo}"
+  gitops_workloads_private_url      = var.gitops_workloads_private_repo == "" ? "" : "${var.gitops_private_org}/${var.gitops_workloads_private_repo}"
   gitops_workloads_private_basepath = var.gitops_workloads_private_basepath
   gitops_workloads_private_revision = var.gitops_workloads_private_revision
 

--- a/terraform/hub-spoke/hub/locals.tf
+++ b/terraform/hub-spoke/hub/locals.tf
@@ -26,6 +26,12 @@ locals {
   gitops_workloads_path     = var.gitops_workloads_path
   gitops_workloads_revision = var.gitops_workloads_revision
 
+  # Private overlay repos (GIT-13) — SSH-accessed, values-only
+  gitops_addons_private_url         = "${var.gitops_private_org}/${var.gitops_addons_private_repo}"
+  gitops_addons_private_revision    = var.gitops_addons_private_revision
+  gitops_workloads_private_url      = "${var.gitops_private_org}/${var.gitops_workloads_private_repo}"
+  gitops_workloads_private_revision = var.gitops_workloads_private_revision
+
   # Cluster labels
   # Argocd secret labels for cluster selector
   argocd_cluster_labels = merge({
@@ -63,6 +69,14 @@ locals {
       workloads_repo_basepath = local.gitops_workloads_basepath
       workloads_repo_path     = local.gitops_workloads_path
       workloads_repo_revision = local.gitops_workloads_revision
+    },
+    {
+      # Private overlay repos (GIT-13). Consumed by catalogue ApplicationSets
+      # only for clusters labelled enable_private_overlays=true.
+      addons_private_repo_url         = local.gitops_addons_private_url
+      addons_private_repo_revision    = local.gitops_addons_private_revision
+      workloads_private_repo_url      = local.gitops_workloads_private_url
+      workloads_private_repo_revision = local.gitops_workloads_private_revision
     },
   )
 

--- a/terraform/hub-spoke/hub/variables.tf
+++ b/terraform/hub-spoke/hub/variables.tf
@@ -196,15 +196,15 @@ variable "gitops_workloads_revision" {
   default     = "main"
 }
 
-# Private overlay Git (GIT-13)
-# Values-only overlay repo layered over the public catalogues; environments/ and
-# clusters/ live at repo root, so a `ref` source consumes only repo + revision.
-# addons and workloads point at the same repo by default (single private repo);
-# set different repos to split them.
+# Private deployments repo (GIT-13). OPT-IN: empty by default so a public-only "trial"
+# install never references it (the root bootstrap appset falls back to the public catalogue).
+# Set the repo name (per cluster, via tfvars) to enable the deployments overlay: the root
+# appset then targets this repo's bootstrap/, which imports the clean public appsets and
+# layers private values + adds extra apps. addons and workloads may share one repo or split.
 variable "gitops_addons_private_repo" {
-  description = "Private overlay repo for addons values"
+  description = "Private deployments repo for addons (empty = trial/public-only; set to opt in)"
   type        = string
-  default     = "gitops-private"
+  default     = ""
 }
 
 variable "gitops_addons_private_basepath" {
@@ -220,9 +220,9 @@ variable "gitops_addons_private_revision" {
 }
 
 variable "gitops_workloads_private_repo" {
-  description = "Private overlay repo for workloads values"
+  description = "Private deployments repo for workloads (empty = trial/public-only; set to opt in)"
   type        = string
-  default     = "gitops-private"
+  default     = ""
 }
 
 variable "gitops_workloads_private_basepath" {

--- a/terraform/hub-spoke/hub/variables.tf
+++ b/terraform/hub-spoke/hub/variables.tf
@@ -104,7 +104,7 @@ variable "addons" {
 variable "allowed_addons" {
   description = "Optional allowlist of known addon flags. Extend here (tfvars) when new add-ons are added to the catalogue."
   type        = list(string)
-  default     = ["argocd", "keycloak", "velero", "cnpg", "private_overlays"]
+  default     = ["argocd", "keycloak", "velero", "cnpg"]
 }
 
 variable "allow_unknown_addons" {
@@ -207,6 +207,12 @@ variable "gitops_addons_private_repo" {
   default     = "gitops-private"
 }
 
+variable "gitops_addons_private_basepath" {
+  description = "Subtree within the private repo for addons (basepath); enables one-repo-or-two"
+  type        = string
+  default     = "addons"
+}
+
 variable "gitops_addons_private_revision" {
   description = "Private overlay repo revision/branch/ref for addons values"
   type        = string
@@ -217,6 +223,12 @@ variable "gitops_workloads_private_repo" {
   description = "Private overlay repo for workloads values"
   type        = string
   default     = "gitops-private"
+}
+
+variable "gitops_workloads_private_basepath" {
+  description = "Subtree within the private repo for workloads (basepath); enables one-repo-or-two"
+  type        = string
+  default     = "workloads"
 }
 
 variable "gitops_workloads_private_revision" {

--- a/terraform/hub-spoke/hub/variables.tf
+++ b/terraform/hub-spoke/hub/variables.tf
@@ -104,7 +104,7 @@ variable "addons" {
 variable "allowed_addons" {
   description = "Optional allowlist of known addon flags. Extend here (tfvars) when new add-ons are added to the catalogue."
   type        = list(string)
-  default     = ["argocd","keycloak","velero","cnpg"]
+  default     = ["argocd", "keycloak", "velero", "cnpg", "private_overlays"]
 }
 
 variable "allow_unknown_addons" {
@@ -118,6 +118,14 @@ variable "gitops_org" {
   description = "Git repository org/user contains for addons"
   type        = string
   default     = "https://github.com/SilexConsulting"
+}
+
+# Private overlay Git org/prefix. Distinct from gitops_org because the private
+# overlay repo is accessed over SSH (deploy key), e.g. "git@github.com:SilexConsulting".
+variable "gitops_private_org" {
+  description = "Git org/prefix (SSH) for the private overlay repo(s)"
+  type        = string
+  default     = "git@github.com:SilexConsulting"
 }
 
 variable "gitops_addons_repo" {
@@ -184,6 +192,35 @@ variable "gitops_workloads_path" {
 
 variable "gitops_workloads_revision" {
   description = "Git repository revision/branch/ref for workload"
+  type        = string
+  default     = "main"
+}
+
+# Private overlay Git (GIT-13)
+# Values-only overlay repo layered over the public catalogues; environments/ and
+# clusters/ live at repo root, so a `ref` source consumes only repo + revision.
+# addons and workloads point at the same repo by default (single private repo);
+# set different repos to split them.
+variable "gitops_addons_private_repo" {
+  description = "Private overlay repo for addons values"
+  type        = string
+  default     = "gitops-private"
+}
+
+variable "gitops_addons_private_revision" {
+  description = "Private overlay repo revision/branch/ref for addons values"
+  type        = string
+  default     = "main"
+}
+
+variable "gitops_workloads_private_repo" {
+  description = "Private overlay repo for workloads values"
+  type        = string
+  default     = "gitops-private"
+}
+
+variable "gitops_workloads_private_revision" {
+  description = "Private overlay repo revision/branch/ref for workloads values"
   type        = string
   default     = "main"
 }

--- a/terraform/hub-spoke/spokes/locals.tf
+++ b/terraform/hub-spoke/spokes/locals.tf
@@ -25,11 +25,13 @@ locals {
   gitops_workloads_path     = var.gitops_workloads_path
   gitops_workloads_revision = var.gitops_workloads_revision
 
-  # Private overlay / deployments repos (GIT-13) — SSH-accessed
-  gitops_addons_private_url         = "${var.gitops_private_org}/${var.gitops_addons_private_repo}"
+  # Private deployments repos (GIT-13) — SSH-accessed. URL is empty unless a repo is set
+  # (opt-in), so a public-only trial cluster emits no private annotation and the root
+  # bootstrap appset falls back to the public catalogue.
+  gitops_addons_private_url         = var.gitops_addons_private_repo == "" ? "" : "${var.gitops_private_org}/${var.gitops_addons_private_repo}"
   gitops_addons_private_basepath    = var.gitops_addons_private_basepath
   gitops_addons_private_revision    = var.gitops_addons_private_revision
-  gitops_workloads_private_url      = "${var.gitops_private_org}/${var.gitops_workloads_private_repo}"
+  gitops_workloads_private_url      = var.gitops_workloads_private_repo == "" ? "" : "${var.gitops_private_org}/${var.gitops_workloads_private_repo}"
   gitops_workloads_private_basepath = var.gitops_workloads_private_basepath
   gitops_workloads_private_revision = var.gitops_workloads_private_revision
 

--- a/terraform/hub-spoke/spokes/locals.tf
+++ b/terraform/hub-spoke/spokes/locals.tf
@@ -25,10 +25,12 @@ locals {
   gitops_workloads_path     = var.gitops_workloads_path
   gitops_workloads_revision = var.gitops_workloads_revision
 
-  # Private overlay repos (GIT-13) — SSH-accessed, values-only
+  # Private overlay / deployments repos (GIT-13) — SSH-accessed
   gitops_addons_private_url         = "${var.gitops_private_org}/${var.gitops_addons_private_repo}"
+  gitops_addons_private_basepath    = var.gitops_addons_private_basepath
   gitops_addons_private_revision    = var.gitops_addons_private_revision
   gitops_workloads_private_url      = "${var.gitops_private_org}/${var.gitops_workloads_private_repo}"
+  gitops_workloads_private_basepath = var.gitops_workloads_private_basepath
   gitops_workloads_private_revision = var.gitops_workloads_private_revision
 
   # Cluster labels
@@ -71,11 +73,13 @@ locals {
       workloads_repo_revision = local.gitops_workloads_revision
     },
     {
-      # Private overlay repos (GIT-13). Consumed by catalogue ApplicationSets
-      # only for clusters labelled enable_private_overlays=true.
+      # Private overlay / deployments repos (GIT-13). Consumed by the private repo's
+      # bootstrap Kustomize (deployments mode) to template per-cluster overlay sources.
       addons_private_repo_url         = local.gitops_addons_private_url
+      addons_private_repo_basepath    = local.gitops_addons_private_basepath
       addons_private_repo_revision    = local.gitops_addons_private_revision
       workloads_private_repo_url      = local.gitops_workloads_private_url
+      workloads_private_repo_basepath = local.gitops_workloads_private_basepath
       workloads_private_repo_revision = local.gitops_workloads_private_revision
     },
   )

--- a/terraform/hub-spoke/spokes/locals.tf
+++ b/terraform/hub-spoke/spokes/locals.tf
@@ -25,6 +25,12 @@ locals {
   gitops_workloads_path     = var.gitops_workloads_path
   gitops_workloads_revision = var.gitops_workloads_revision
 
+  # Private overlay repos (GIT-13) — SSH-accessed, values-only
+  gitops_addons_private_url         = "${var.gitops_private_org}/${var.gitops_addons_private_repo}"
+  gitops_addons_private_revision    = var.gitops_addons_private_revision
+  gitops_workloads_private_url      = "${var.gitops_private_org}/${var.gitops_workloads_private_repo}"
+  gitops_workloads_private_revision = var.gitops_workloads_private_revision
+
   # Cluster labels
   # Argocd secret labels for cluster selector
   argocd_cluster_labels = merge({
@@ -63,6 +69,14 @@ locals {
       workloads_repo_basepath = local.gitops_workloads_basepath
       workloads_repo_path     = local.gitops_workloads_path
       workloads_repo_revision = local.gitops_workloads_revision
+    },
+    {
+      # Private overlay repos (GIT-13). Consumed by catalogue ApplicationSets
+      # only for clusters labelled enable_private_overlays=true.
+      addons_private_repo_url         = local.gitops_addons_private_url
+      addons_private_repo_revision    = local.gitops_addons_private_revision
+      workloads_private_repo_url      = local.gitops_workloads_private_url
+      workloads_private_repo_revision = local.gitops_workloads_private_revision
     },
   )
 

--- a/terraform/hub-spoke/spokes/variables.tf
+++ b/terraform/hub-spoke/spokes/variables.tf
@@ -196,15 +196,15 @@ variable "gitops_workloads_revision" {
   default     = "main"
 }
 
-# Private overlay Git (GIT-13)
-# Values-only overlay repo layered over the public catalogues; environments/ and
-# clusters/ live at repo root, so a `ref` source consumes only repo + revision.
-# addons and workloads point at the same repo by default (single private repo);
-# set different repos to split them.
+# Private deployments repo (GIT-13). OPT-IN: empty by default so a public-only "trial"
+# install never references it (the root bootstrap appset falls back to the public catalogue).
+# Set the repo name (per cluster, via tfvars) to enable the deployments overlay: the root
+# appset then targets this repo's bootstrap/, which imports the clean public appsets and
+# layers private values + adds extra apps. addons and workloads may share one repo or split.
 variable "gitops_addons_private_repo" {
-  description = "Private overlay repo for addons values"
+  description = "Private deployments repo for addons (empty = trial/public-only; set to opt in)"
   type        = string
-  default     = "gitops-private"
+  default     = ""
 }
 
 variable "gitops_addons_private_basepath" {
@@ -220,9 +220,9 @@ variable "gitops_addons_private_revision" {
 }
 
 variable "gitops_workloads_private_repo" {
-  description = "Private overlay repo for workloads values"
+  description = "Private deployments repo for workloads (empty = trial/public-only; set to opt in)"
   type        = string
-  default     = "gitops-private"
+  default     = ""
 }
 
 variable "gitops_workloads_private_basepath" {

--- a/terraform/hub-spoke/spokes/variables.tf
+++ b/terraform/hub-spoke/spokes/variables.tf
@@ -104,7 +104,7 @@ variable "addons" {
 variable "allowed_addons" {
   description = "Optional allowlist of known addon flags. Extend here (tfvars) when new add-ons are added to the catalogue."
   type        = list(string)
-  default     = ["argocd", "keycloak", "velero", "cnpg", "private_overlays"]
+  default     = ["argocd", "keycloak", "velero", "cnpg"]
 }
 
 variable "allow_unknown_addons" {
@@ -207,6 +207,12 @@ variable "gitops_addons_private_repo" {
   default     = "gitops-private"
 }
 
+variable "gitops_addons_private_basepath" {
+  description = "Subtree within the private repo for addons (basepath); enables one-repo-or-two"
+  type        = string
+  default     = "addons"
+}
+
 variable "gitops_addons_private_revision" {
   description = "Private overlay repo revision/branch/ref for addons values"
   type        = string
@@ -217,6 +223,12 @@ variable "gitops_workloads_private_repo" {
   description = "Private overlay repo for workloads values"
   type        = string
   default     = "gitops-private"
+}
+
+variable "gitops_workloads_private_basepath" {
+  description = "Subtree within the private repo for workloads (basepath); enables one-repo-or-two"
+  type        = string
+  default     = "workloads"
 }
 
 variable "gitops_workloads_private_revision" {

--- a/terraform/hub-spoke/spokes/variables.tf
+++ b/terraform/hub-spoke/spokes/variables.tf
@@ -104,7 +104,7 @@ variable "addons" {
 variable "allowed_addons" {
   description = "Optional allowlist of known addon flags. Extend here (tfvars) when new add-ons are added to the catalogue."
   type        = list(string)
-  default     = ["argocd","keycloak","velero","cnpg"]
+  default     = ["argocd", "keycloak", "velero", "cnpg", "private_overlays"]
 }
 
 variable "allow_unknown_addons" {
@@ -118,6 +118,14 @@ variable "gitops_org" {
   description = "Git repository org/user contains for addons"
   type        = string
   default     = "https://github.com/SilexConsulting"
+}
+
+# Private overlay Git org/prefix. Distinct from gitops_org because the private
+# overlay repo is accessed over SSH (deploy key), e.g. "git@github.com:SilexConsulting".
+variable "gitops_private_org" {
+  description = "Git org/prefix (SSH) for the private overlay repo(s)"
+  type        = string
+  default     = "git@github.com:SilexConsulting"
 }
 
 variable "gitops_addons_repo" {
@@ -184,6 +192,35 @@ variable "gitops_workloads_path" {
 
 variable "gitops_workloads_revision" {
   description = "Git repository revision/branch/ref for workload"
+  type        = string
+  default     = "main"
+}
+
+# Private overlay Git (GIT-13)
+# Values-only overlay repo layered over the public catalogues; environments/ and
+# clusters/ live at repo root, so a `ref` source consumes only repo + revision.
+# addons and workloads point at the same repo by default (single private repo);
+# set different repos to split them.
+variable "gitops_addons_private_repo" {
+  description = "Private overlay repo for addons values"
+  type        = string
+  default     = "gitops-private"
+}
+
+variable "gitops_addons_private_revision" {
+  description = "Private overlay repo revision/branch/ref for addons values"
+  type        = string
+  default     = "main"
+}
+
+variable "gitops_workloads_private_repo" {
+  description = "Private overlay repo for workloads values"
+  type        = string
+  default     = "gitops-private"
+}
+
+variable "gitops_workloads_private_revision" {
+  description = "Private overlay repo revision/branch/ref for workloads values"
   type        = string
   default     = "main"
 }

--- a/terraform/on-prem/locals.tf
+++ b/terraform/on-prem/locals.tf
@@ -24,11 +24,13 @@ locals {
   gitops_workloads_path     = var.gitops_workloads_path
   gitops_workloads_revision = var.gitops_workloads_revision
 
-  # Private overlay / deployments repos (GIT-13) — SSH-accessed
-  gitops_addons_private_url         = "${var.gitops_private_org}/${var.gitops_addons_private_repo}"
+  # Private deployments repos (GIT-13) — SSH-accessed. URL is empty unless a repo is set
+  # (opt-in), so a public-only trial cluster emits no private annotation and the root
+  # bootstrap appset falls back to the public catalogue.
+  gitops_addons_private_url         = var.gitops_addons_private_repo == "" ? "" : "${var.gitops_private_org}/${var.gitops_addons_private_repo}"
   gitops_addons_private_basepath    = var.gitops_addons_private_basepath
   gitops_addons_private_revision    = var.gitops_addons_private_revision
-  gitops_workloads_private_url      = "${var.gitops_private_org}/${var.gitops_workloads_private_repo}"
+  gitops_workloads_private_url      = var.gitops_workloads_private_repo == "" ? "" : "${var.gitops_private_org}/${var.gitops_workloads_private_repo}"
   gitops_workloads_private_basepath = var.gitops_workloads_private_basepath
   gitops_workloads_private_revision = var.gitops_workloads_private_revision
 

--- a/terraform/on-prem/locals.tf
+++ b/terraform/on-prem/locals.tf
@@ -24,10 +24,12 @@ locals {
   gitops_workloads_path     = var.gitops_workloads_path
   gitops_workloads_revision = var.gitops_workloads_revision
 
-  # Private overlay repos (GIT-13) — SSH-accessed, values-only
+  # Private overlay / deployments repos (GIT-13) — SSH-accessed
   gitops_addons_private_url         = "${var.gitops_private_org}/${var.gitops_addons_private_repo}"
+  gitops_addons_private_basepath    = var.gitops_addons_private_basepath
   gitops_addons_private_revision    = var.gitops_addons_private_revision
   gitops_workloads_private_url      = "${var.gitops_private_org}/${var.gitops_workloads_private_repo}"
+  gitops_workloads_private_basepath = var.gitops_workloads_private_basepath
   gitops_workloads_private_revision = var.gitops_workloads_private_revision
 
   # Cluster labels
@@ -66,11 +68,13 @@ locals {
       workloads_repo_revision = local.gitops_workloads_revision
     },
     {
-      # Private overlay repos (GIT-13). Consumed by catalogue ApplicationSets
-      # only for clusters labelled enable_private_overlays=true.
+      # Private overlay / deployments repos (GIT-13). Consumed by the private repo's
+      # bootstrap Kustomize (deployments mode) to template per-cluster overlay sources.
       addons_private_repo_url         = local.gitops_addons_private_url
+      addons_private_repo_basepath    = local.gitops_addons_private_basepath
       addons_private_repo_revision    = local.gitops_addons_private_revision
       workloads_private_repo_url      = local.gitops_workloads_private_url
+      workloads_private_repo_basepath = local.gitops_workloads_private_basepath
       workloads_private_repo_revision = local.gitops_workloads_private_revision
     },
   )

--- a/terraform/on-prem/locals.tf
+++ b/terraform/on-prem/locals.tf
@@ -24,6 +24,12 @@ locals {
   gitops_workloads_path     = var.gitops_workloads_path
   gitops_workloads_revision = var.gitops_workloads_revision
 
+  # Private overlay repos (GIT-13) — SSH-accessed, values-only
+  gitops_addons_private_url         = "${var.gitops_private_org}/${var.gitops_addons_private_repo}"
+  gitops_addons_private_revision    = var.gitops_addons_private_revision
+  gitops_workloads_private_url      = "${var.gitops_private_org}/${var.gitops_workloads_private_repo}"
+  gitops_workloads_private_revision = var.gitops_workloads_private_revision
+
   # Cluster labels
   argocd_cluster_labels = merge({
     cloud   = local.cloud
@@ -58,6 +64,14 @@ locals {
       workloads_repo_basepath = local.gitops_workloads_basepath
       workloads_repo_path     = local.gitops_workloads_path
       workloads_repo_revision = local.gitops_workloads_revision
+    },
+    {
+      # Private overlay repos (GIT-13). Consumed by catalogue ApplicationSets
+      # only for clusters labelled enable_private_overlays=true.
+      addons_private_repo_url         = local.gitops_addons_private_url
+      addons_private_repo_revision    = local.gitops_addons_private_revision
+      workloads_private_repo_url      = local.gitops_workloads_private_url
+      workloads_private_repo_revision = local.gitops_workloads_private_revision
     },
   )
 

--- a/terraform/on-prem/variables.tf
+++ b/terraform/on-prem/variables.tf
@@ -170,15 +170,15 @@ variable "gitops_workloads_revision" {
   default     = "main"
 }
 
-# Private overlay Git (GIT-13)
-# Values-only overlay repo layered over the public catalogues; environments/ and
-# clusters/ live at repo root, so a `ref` source consumes only repo + revision.
-# addons and workloads point at the same repo by default (single private repo);
-# set different repos to split them.
+# Private deployments repo (GIT-13). OPT-IN: empty by default so a public-only "trial"
+# install never references it (the root bootstrap appset falls back to the public catalogue).
+# Set the repo name (per cluster, via tfvars) to enable the deployments overlay: the root
+# appset then targets this repo's bootstrap/, which imports the clean public appsets and
+# layers private values + adds extra apps. addons and workloads may share one repo or split.
 variable "gitops_addons_private_repo" {
-  description = "Private overlay repo for addons values"
+  description = "Private deployments repo for addons (empty = trial/public-only; set to opt in)"
   type        = string
-  default     = "gitops-private"
+  default     = ""
 }
 
 variable "gitops_addons_private_basepath" {
@@ -194,9 +194,9 @@ variable "gitops_addons_private_revision" {
 }
 
 variable "gitops_workloads_private_repo" {
-  description = "Private overlay repo for workloads values"
+  description = "Private deployments repo for workloads (empty = trial/public-only; set to opt in)"
   type        = string
-  default     = "gitops-private"
+  default     = ""
 }
 
 variable "gitops_workloads_private_basepath" {

--- a/terraform/on-prem/variables.tf
+++ b/terraform/on-prem/variables.tf
@@ -84,7 +84,7 @@ variable "addons" {
 variable "allowed_addons" {
   description = "Optional allowlist of known addon flags."
   type        = list(string)
-  default     = ["argocd", "keycloak", "velero", "cnpg", "private_overlays"]
+  default     = ["argocd", "keycloak", "velero", "cnpg"]
 }
 
 # Addons Git
@@ -181,6 +181,12 @@ variable "gitops_addons_private_repo" {
   default     = "gitops-private"
 }
 
+variable "gitops_addons_private_basepath" {
+  description = "Subtree within the private repo for addons (basepath); enables one-repo-or-two"
+  type        = string
+  default     = "addons"
+}
+
 variable "gitops_addons_private_revision" {
   description = "Private overlay repo revision/branch/ref for addons values"
   type        = string
@@ -191,6 +197,12 @@ variable "gitops_workloads_private_repo" {
   description = "Private overlay repo for workloads values"
   type        = string
   default     = "gitops-private"
+}
+
+variable "gitops_workloads_private_basepath" {
+  description = "Subtree within the private repo for workloads (basepath); enables one-repo-or-two"
+  type        = string
+  default     = "workloads"
 }
 
 variable "gitops_workloads_private_revision" {

--- a/terraform/on-prem/variables.tf
+++ b/terraform/on-prem/variables.tf
@@ -84,7 +84,7 @@ variable "addons" {
 variable "allowed_addons" {
   description = "Optional allowlist of known addon flags."
   type        = list(string)
-  default     = ["argocd","keycloak","velero","cnpg"]
+  default     = ["argocd", "keycloak", "velero", "cnpg", "private_overlays"]
 }
 
 # Addons Git
@@ -92,6 +92,14 @@ variable "gitops_org" {
   description = "Git repository org/user contains for addons"
   type        = string
   default     = "https://github.com/SilexConsulting"
+}
+
+# Private overlay Git org/prefix. Distinct from gitops_org because the private
+# overlay repo is accessed over SSH (deploy key), e.g. "git@github.com:SilexConsulting".
+variable "gitops_private_org" {
+  description = "Git org/prefix (SSH) for the private overlay repo(s)"
+  type        = string
+  default     = "git@github.com:SilexConsulting"
 }
 
 variable "gitops_addons_repo" {
@@ -158,6 +166,35 @@ variable "gitops_workloads_path" {
 
 variable "gitops_workloads_revision" {
   description = "Git repository revision/branch/ref for workload"
+  type        = string
+  default     = "main"
+}
+
+# Private overlay Git (GIT-13)
+# Values-only overlay repo layered over the public catalogues; environments/ and
+# clusters/ live at repo root, so a `ref` source consumes only repo + revision.
+# addons and workloads point at the same repo by default (single private repo);
+# set different repos to split them.
+variable "gitops_addons_private_repo" {
+  description = "Private overlay repo for addons values"
+  type        = string
+  default     = "gitops-private"
+}
+
+variable "gitops_addons_private_revision" {
+  description = "Private overlay repo revision/branch/ref for addons values"
+  type        = string
+  default     = "main"
+}
+
+variable "gitops_workloads_private_repo" {
+  description = "Private overlay repo for workloads values"
+  type        = string
+  default     = "gitops-private"
+}
+
+variable "gitops_workloads_private_revision" {
+  description = "Private overlay repo revision/branch/ref for workloads values"
   type        = string
   default     = "main"
 }


### PR DESCRIPTION
## Summary

Adds **GIT-13**: an opt-in "deployments" repo that layers private values over the public catalogues **and** adds net-new apps — without ever forking the public repos. A cluster opts in purely by annotating its Argo CD cluster secret with a private repo URL; with no annotation, a public-only "trial" install works unchanged.

## How it works

- **Public catalogues stay canonical.** `*_repo_url` is never repointed, so every child appset keeps sourcing its `$values`/`$workloads` base from the public repo.
- **Opt-in via Terraform.** `gitops_{addons,workloads}_private_repo` now default to `""`; locals emit the private URL only when a repo is set. Trial clusters emit no private annotation.
- **Root appsets choose the source.** `bootstrap/hub/{addons,workloads}.yaml` become `goTemplate` and switch on `{addons,workloads}_private_repo_url`:
  - set → target the private repo's `<basepath>/bootstrap` (a Kustomize build that imports the clean public appsets, layers private values, and adds extra apps)
  - unset → the public catalogue directory (trial); `directory.recurse` is re-added via `spec.templatePatch` (structural toggles can't live in `template`).
- The private repo carries the Kustomize patching; the public repos never reference it.

Also fixes a latent bug: an invalid `preserveResourcesOnDeletion` under `template.spec.syncPolicy` in `workloads.yaml` (an ApplicationSet-level field, not valid on an Application; `kubectl apply` strict-decodes and rejects it).

Design doc: `docs/private-overlays-design.md`.

## Verified live (kind hub/spoke)

Flipped the local hub to deployments mode against `gitops-private`:

- `addons` root Synced/Healthy off the private repo's Kustomize.
- **Argo repo-server builds remote Kustomize bases** with default config (the main risk).
- `velero-ui` gained a `ref: private` source + private valueFiles and **scaled 1→2 replicas** from a private cluster value — public base source unforked.
- Net-new **podinfo** addon deployed (not present in the public catalogue).
- SSH deploy-key auth to the private repo works.

## Scope / follow-ups

- Terraform changes span all three stacks (on-prem, hub, spokes); `terraform validate` passes on each.
- Workloads overlay uses the same mechanism but needs a `type: workload` spoke to exercise.
- **ESO** (runtime secrets, GIT-6/GIT-10 + GIT-7) is required by the AC and still blocks final GIT-13 closure — tracked separately.
