### PR TITLE
GIT-24: CI (reusable gitops-ci) + pre-commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,13 @@
+name: ci
+on:
+  pull_request:
+  push:
+    branches: [main]
+jobs:
+  ci:
+    uses: SilexConsulting/.github/.github/workflows/gitops-ci.yml@main
+    with:
+      kubernetes: true
+      kustomize_exclude: "bootstrap/argocd"   # sops/ksops build — needs the age key, skip in CI
+      terraform: true
+      terraform_dirs: "terraform/on-prem terraform/hub-spoke/hub terraform/hub-spoke/spokes"

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,11 @@
+# gitleaks config for CI (GIT-24). Extends the default ruleset; allowlists files that
+# legitimately contain key-shaped placeholders or ciphertext (not real plaintext secrets).
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Documented example secret template + SOPS-encrypted files"
+paths = [
+  '''bootstrap/argocd/secrets\.yaml$''',   # example (real secrets live in secrets.enc.yaml, SOPS)
+  '''.*\.enc\.yaml$''',                     # SOPS-encrypted
+]

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,17 @@
+{
+  "default": true,
+  "MD001": false,
+  "MD009": false,
+  "MD012": false,
+  "MD013": false,
+  "MD022": false,
+  "MD025": false,
+  "MD026": false,
+  "MD031": false,
+  "MD032": false,
+  "MD033": false,
+  "MD034": false,
+  "MD040": false,
+  "MD041": false,
+  "MD060": false
+}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,15 +1,32 @@
-# Local mirror of the shared CI (GIT-24). Run: pipx install pre-commit && pre-commit run -a
+# Local checks (union of the repo's original hooks + GIT-24 additions).
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v4.6.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-merge-conflict
+      - id: check-yaml
+        args: [--allow-multiple-documents]
   - repo: https://github.com/adrienverge/yamllint
     rev: v1.35.1
     hooks:
       - id: yamllint
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.41.0
+    hooks:
+      - id: markdownlint
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.10.0.1
+    hooks:
+      - id: shellcheck
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v3.3.3
+    hooks:
+      - id: prettier
+        additional_dependencies:
+          - prettier@3.3.3
+        types_or: [yaml, markdown]
   - repo: https://github.com/gitleaks/gitleaks
     rev: v8.21.2
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,27 +1,27 @@
+# Local mirror of the shared CI (GIT-24). Run: pipx install pre-commit && pre-commit run -a
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-merge-conflict
-      - id: check-yaml
   - repo: https://github.com/adrienverge/yamllint
     rev: v1.35.1
     hooks:
       - id: yamllint
-  - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.41.0
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.21.2
     hooks:
-      - id: markdownlint
-  - repo: https://github.com/shellcheck-py/shellcheck-py
-    rev: v0.10.0.1
+      - id: gitleaks
+  - repo: https://github.com/antonbabenko/pre-commit-terraform
+    rev: v1.96.1
     hooks:
-      - id: shellcheck
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.3.3
+      - id: terraform_fmt
+  - repo: local
     hooks:
-      - id: prettier
-        additional_dependencies:
-          - prettier@3.3.3
-        types_or: [yaml, markdown]
+      - id: sops-encrypted
+        name: "sops-encrypted (enc.yaml must be encrypted)"
+        entry: "bash -c 'for f in \"$@\"; do grep -Eq \"sops:|ENC\\[\" \"$f\" || { echo \"not-encrypted $f\"; exit 1; }; done' --"
+        language: system
+        files: "\\.enc\\.yaml$"

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,14 @@
+extends: relaxed
+rules:
+  line-length: disable
+  document-start: disable
+  trailing-spaces:
+    level: warning
+  new-line-at-end-of-file:
+    level: warning
+# Helm chart templates and encrypted files are not plain YAML.
+ignore: |
+  **/charts/**
+  **/templates/**
+  *.enc.yaml
+  demo/**


### PR DESCRIPTION
CI (GIT-24): thin caller that invokes the shared reusable workflow `SilexConsulting/.github/.github/workflows/gitops-ci.yml@main`.

Blocking gates: yamllint (relaxed), SOPS-encrypted check on `*.enc.yaml`, gitleaks, `kustomize build` of every overlay, kubeconform (community CRD catalogue for Argo/CNPG/ESO). Advisory (non-blocking v1): tflint, checkov.

Also adds `.pre-commit-config.yaml` + `.yamllint` for local runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This repo also runs **terraform fmt + validate** across the 3 stacks (on-prem, hub-spoke/hub, hub-spoke/spokes), and excludes `bootstrap/argocd` from kustomize build (sops/ksops needs the age key).