### PR TITLE
fix(docs): markdownlint MD036 in git-20 design doc (green main CI)

### DIFF
--- a/docs/git-20-resources-design.md
+++ b/docs/git-20-resources-design.md
@@ -21,7 +21,7 @@ resources without mutating the public catalogues.
 
 ## Design goals / non-goals
 
-**Goals**
+#### Goals
 - Keep the current repository structure for add-ons and workloads intact; only add paths.
 - A discoverable, low-ceremony convention: add a manifest + list it in a `kustomization.yaml`
   and it reconciles to the target cluster.
@@ -30,7 +30,7 @@ resources without mutating the public catalogues.
 - Resources are overridable/augmentable per environment and per cluster, and from the private
   deployments repo, via **Kustomize**.
 
-**Non-goals**
+#### Non-goals
 - No change to operator/add-on installation (still via add-ons).
 - No broad repo rearrangement — only additive paths and manifests.
 - No hard cross-Application ordering barrier; **eventual consistency** (Argo retry) is accepted.


### PR DESCRIPTION
The GIT-20 design doc used `**Goals**`/`**Non-goals**` as bold pseudo-headings, tripping markdownlint MD036 once GIT-20 + GIT-24 landed on main. Converted to real `####` headings — main CI markdownlint back to green. (Rule kept enabled; only my content was wrong.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)